### PR TITLE
Dropdown button atom

### DIFF
--- a/src/components/shared/buttons/DropdownButton.vue
+++ b/src/components/shared/buttons/DropdownButton.vue
@@ -50,8 +50,3 @@
         },
     }
 </script>
-
-<style scoped>
-
-</style>
-

--- a/src/components/shared/buttons/DropdownButton.vue
+++ b/src/components/shared/buttons/DropdownButton.vue
@@ -1,6 +1,6 @@
 
 <template>
-    <div class="ui floating dropdown icon button" ref="dropdown" :class="{disabled: loading}">
+    <div class="ui floating dropdown icon button" ref="dropdown" :class="{disabled: loading || disabled}">
         <i class="dropdown icon" ></i>
         <div class="menu">
             <div v-for="item in menu" class="item" @click="item.action" :key="item.title">{{ item.title }}</div>
@@ -30,6 +30,14 @@
             * Loading flag to disable element
             */
             loading: {
+                type: Boolean,
+                default: false,
+            },
+
+            /*
+            * Disabled flag to disable element
+            */
+            disabled: {
                 type: Boolean,
                 default: false,
             },

--- a/src/components/shared/buttons/DropdownButton.vue
+++ b/src/components/shared/buttons/DropdownButton.vue
@@ -1,0 +1,49 @@
+
+<template>
+    <div class="ui floating dropdown icon button" ref="dropdown" :class="{disabled: loading}">
+        <i class="dropdown icon" ></i>
+        <div class="menu">
+            <div v-for="item in menu" class="item" @click="item.action" :key="item.title">{{ item.title }}</div>
+        </div>
+    </div>
+</template>
+
+<script>
+    /**
+    * Dropdown button atom that is designed to be used in a group of buttons to add more options to the main button
+    *
+    * @example ./croud-dropdown-button.md
+    */
+    export default {
+        name: 'croud-dropdown-button',
+
+        props: {
+            /*
+            * Array of menu item objects in the format {title: foo, action() {console.log()}}
+            */
+            menu: {
+                type: Array,
+                default: () => [],
+            },
+
+            /*
+            * Loading flag to disable element
+            */
+            loading: {
+                type: Boolean,
+                default: false,
+            },
+        },
+
+        mounted() {
+            $(this.$refs.dropdown).dropdown({
+                action: 'hide',
+            })
+        },
+    }
+</script>
+
+<style scoped>
+
+</style>
+

--- a/src/components/shared/buttons/croud-dropdown-button.md
+++ b/src/components/shared/buttons/croud-dropdown-button.md
@@ -1,0 +1,9 @@
+### Basic usage
+Use **menu** prop to populate the dropdown options
+
+    <croud-dropdown-button :menu="[{title: 'Foo', action: () => $toasted.show('Foo')}, {title: 'Bar', action: () => $toasted.show('Bar')}]"/>
+
+### Loading
+Use **loading** prop to set loading state, when loading the dropdown is disabled
+
+    <croud-dropdown-button :loading="true"/>

--- a/src/components/shared/buttons/croud-dropdown-button.md
+++ b/src/components/shared/buttons/croud-dropdown-button.md
@@ -7,3 +7,9 @@ Use **menu** prop to populate the dropdown options
 Use **loading** prop to set loading state, when loading the dropdown is disabled
 
     <croud-dropdown-button :loading="true"/>
+
+
+### Disabled
+Use **disabled** prop to disable dropdown
+
+    <croud-dropdown-button :disabled="true"/>

--- a/test/unit/buttons/DropdownButton.spec.js
+++ b/test/unit/buttons/DropdownButton.spec.js
@@ -1,0 +1,31 @@
+
+import Vue from 'vue'
+import DropdownButton from '../../../src/components/shared/buttons/DropdownButton'
+import '../../../semantic/dist/semantic'
+
+
+const Constructor = Vue.extend(DropdownButton)
+
+const vm = new Constructor({
+    propsData: {
+        menu: [
+            { title: 'foo', action: () => console.log('foo') },
+            { title: 'bar', action: () => console.log('bar') },
+        ],
+        loading: false,
+    },
+}).$mount()
+
+describe('DropdownButton', () => {
+    it('should match the snapshot', () => {
+        expect(vm.$el).toMatchSnapshot()
+    })
+
+    it('should disable the dropdown if loading', (done) => {
+        vm.loading = true
+        vm.$nextTick(() => {
+            expect(vm.$el).toMatchSnapshot()
+            done()
+        })
+    })
+})

--- a/test/unit/buttons/__snapshots__/DropdownButton.spec.js.snap
+++ b/test/unit/buttons/__snapshots__/DropdownButton.spec.js.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DropdownButton should disable the dropdown if loading 1`] = `
+<div
+  class="ui floating dropdown icon button disabled"
+  tabindex="0"
+>
+  <i
+    class="dropdown icon"
+  />
+  <div
+    class="menu"
+    tabindex="-1"
+  >
+    <div
+      class="item"
+    >
+      foo
+    </div>
+    <div
+      class="item"
+    >
+      bar
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DropdownButton should match the snapshot 1`] = `
+<div
+  class="ui floating dropdown icon button"
+  tabindex="0"
+>
+  <i
+    class="dropdown icon"
+  />
+  <div
+    class="menu"
+    tabindex="-1"
+  >
+    <div
+      class="item"
+    >
+      foo
+    </div>
+    <div
+      class="item"
+    >
+      bar
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Simple atom for building a button dropdown, this generic component will be used along with the Save button atom to build a Save button with options.

Complete with tests and generated with hygen