### PR TITLE
Save button atom

### DIFF
--- a/src/components/shared/buttons/SaveButton.vue
+++ b/src/components/shared/buttons/SaveButton.vue
@@ -26,8 +26,3 @@
         },
     }
 </script>
-
-<style scoped>
-
-</style>
-

--- a/src/components/shared/buttons/SaveButton.vue
+++ b/src/components/shared/buttons/SaveButton.vue
@@ -1,0 +1,33 @@
+<script>
+    /**
+    * Our opinionated save button with loading and disabled state.
+    *
+    * *This is a functional component which has no state so does not need to define any props*
+    * @see https://vuejs.org/v2/guide/render-function.html#Functional-Components
+    *
+    * @example ./croud-save-button.md
+    */
+    export default {
+        functional: true,
+        name: 'croud-save-button',
+        render(h, context) {
+            return h('button', {
+                class: {
+                    ui: true,
+                    blue: true,
+                    button: true,
+                    loading: context.props.loading,
+                },
+                attrs: {
+                    disabled: context.props.loading,
+                },
+                on: context.listeners,
+            }, 'Save')
+        },
+    }
+</script>
+
+<style scoped>
+
+</style>
+

--- a/src/components/shared/buttons/SaveButton.vue
+++ b/src/components/shared/buttons/SaveButton.vue
@@ -19,7 +19,7 @@
                     loading: context.props.loading,
                 },
                 attrs: {
-                    disabled: context.props.loading,
+                    disabled: context.props.loading || context.props.disabled,
                 },
                 on: context.listeners,
             }, 'Save')

--- a/src/components/shared/buttons/croud-save-button.md
+++ b/src/components/shared/buttons/croud-save-button.md
@@ -1,0 +1,11 @@
+### Basic usage
+
+    <croud-save-button @click="$toasted.success('saved')"/>
+
+### Loading State
+Use the loading prop to pass through the components loading state.
+
+When this component is in a loading state, it is disabled and so the click listener will not fire
+
+    <croud-save-button :loading="true" @click="$toasted.success('saved')"/>
+

--- a/src/components/shared/buttons/croud-save-button.md
+++ b/src/components/shared/buttons/croud-save-button.md
@@ -9,3 +9,7 @@ When this component is in a loading state, it is disabled and so the click liste
 
     <croud-save-button :loading="true" @click="$toasted.success('saved')"/>
 
+### Disabled state
+You can also use the disabled prop to disable the button
+
+    <croud-save-button :disabled="true" @click="$toasted.success('saved')"/>

--- a/test/unit/buttons/SaveButton.spec.js
+++ b/test/unit/buttons/SaveButton.spec.js
@@ -1,0 +1,38 @@
+
+import Vue from 'vue'
+import SaveButton from '../../../src/components/shared/buttons/SaveButton'
+
+const Constructor = Vue.extend({
+    props: {
+        loading: {},
+    },
+    render(h) {
+        return h(SaveButton, {
+            props: {
+                loading: this.loading,
+            },
+        })
+    },
+})
+
+const vm = new Constructor({
+    propsData: {
+        loading: false,
+    },
+}).$mount()
+
+describe('SaveButton', () => {
+    it('should match the snapshot', () => {
+        expect(vm.$el).toMatchSnapshot()
+        expect(vm.$el.disabled).toBe(false)
+    })
+
+    it('should handle a loading state', (done) => {
+        vm.loading = true
+        vm.$nextTick(() => {
+            expect(vm.$el.classList).toContain('loading')
+            expect(vm.$el.disabled).toBe(true)
+            done()
+        })
+    })
+})

--- a/test/unit/buttons/__snapshots__/SaveButton.spec.js.snap
+++ b/test/unit/buttons/__snapshots__/SaveButton.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SaveButton should match the snapshot 1`] = `
+<button
+  class="ui blue button"
+>
+  Save
+</button>
+`;


### PR DESCRIPTION
New light weight functional component to work as our general usage opinionated SaveButton atom.
We are using a [functional component](https://vuejs.org/v2/guide/render-function.html#Functional-Components) for the Save Button atom as it doesn't need any state and will dramatically cut down on resources and load times. 

Complete with tests and built with the generator.