### PR TITLE
Save with dropdown molecule

### DIFF
--- a/src/components/shared/buttons/DropdownButton.vue
+++ b/src/components/shared/buttons/DropdownButton.vue
@@ -1,6 +1,6 @@
 
 <template>
-    <div class="ui floating dropdown icon button" ref="dropdown" :class="{disabled: loading}">
+    <div class="ui floating dropdown icon button" ref="dropdown" :class="{disabled: loading || disabled}">
         <i class="dropdown icon" ></i>
         <div class="menu">
             <div v-for="item in menu" class="item" @click="item.action" :key="item.title">{{ item.title }}</div>
@@ -33,6 +33,14 @@
                 type: Boolean,
                 default: false,
             },
+
+            /*
+            * Disabled flag to disable element
+            */
+            disabled: {
+                type: Boolean,
+                default: false,
+            },
         },
 
         mounted() {
@@ -42,8 +50,3 @@
         },
     }
 </script>
-
-<style scoped>
-
-</style>
-

--- a/src/components/shared/buttons/DropdownButton.vue
+++ b/src/components/shared/buttons/DropdownButton.vue
@@ -1,0 +1,49 @@
+
+<template>
+    <div class="ui floating dropdown icon button" ref="dropdown" :class="{disabled: loading}">
+        <i class="dropdown icon" ></i>
+        <div class="menu">
+            <div v-for="item in menu" class="item" @click="item.action" :key="item.title">{{ item.title }}</div>
+        </div>
+    </div>
+</template>
+
+<script>
+    /**
+    * Dropdown button atom that is designed to be used in a group of buttons to add more options to the main button
+    *
+    * @example ./croud-dropdown-button.md
+    */
+    export default {
+        name: 'croud-dropdown-button',
+
+        props: {
+            /*
+            * Array of menu item objects in the format {title: foo, action() {console.log()}}
+            */
+            menu: {
+                type: Array,
+                default: () => [],
+            },
+
+            /*
+            * Loading flag to disable element
+            */
+            loading: {
+                type: Boolean,
+                default: false,
+            },
+        },
+
+        mounted() {
+            $(this.$refs.dropdown).dropdown({
+                action: 'hide',
+            })
+        },
+    }
+</script>
+
+<style scoped>
+
+</style>
+

--- a/src/components/shared/buttons/SaveButton.vue
+++ b/src/components/shared/buttons/SaveButton.vue
@@ -1,0 +1,33 @@
+<script>
+    /**
+    * Our opinionated save button with loading and disabled state.
+    *
+    * *This is a functional component which has no state so does not need to define any props*
+    * @see https://vuejs.org/v2/guide/render-function.html#Functional-Components
+    *
+    * @example ./croud-save-button.md
+    */
+    export default {
+        functional: true,
+        name: 'croud-save-button',
+        render(h, context) {
+            return h('button', {
+                class: {
+                    ui: true,
+                    blue: true,
+                    button: true,
+                    loading: context.props.loading,
+                },
+                attrs: {
+                    disabled: context.props.loading,
+                },
+                on: context.listeners,
+            }, 'Save')
+        },
+    }
+</script>
+
+<style scoped>
+
+</style>
+

--- a/src/components/shared/buttons/SaveButton.vue
+++ b/src/components/shared/buttons/SaveButton.vue
@@ -19,15 +19,10 @@
                     loading: context.props.loading,
                 },
                 attrs: {
-                    disabled: context.props.loading,
+                    disabled: context.props.loading || context.props.disabled,
                 },
                 on: context.listeners,
             }, 'Save')
         },
     }
 </script>
-
-<style scoped>
-
-</style>
-

--- a/src/components/shared/buttons/SaveButtonWithDropdown.vue
+++ b/src/components/shared/buttons/SaveButtonWithDropdown.vue
@@ -1,0 +1,43 @@
+
+<script>
+    import Save from './SaveButton'
+    import DropdownButton from './DropdownButton'
+
+    /**
+    * Combination of Save Button atom and Dropdown Button atom to provide additional options to the Save Button
+    *
+    * *This is a functional component which has no state so does not need to define any props*
+    * @see https://vuejs.org/v2/guide/render-function.html#Functional-Components
+    * @see https://croudsupport.github.io/Croud-Style-Guide/technical/#!/croud-save-button
+    * @see https://croudsupport.github.io/Croud-Style-Guide/technical/#!/croud-dropdown-button
+    *
+    * @example ./croud-save-button-with-dropdown.md
+    */
+    export default {
+        functional: true,
+
+        name: 'croud-save-button-with-dropdown',
+
+        render(createElement, context) {
+            return createElement('div',
+                {
+                    class: 'ui blue buttons',
+                },
+                [
+                    createElement(Save, {
+                        props: context.props,
+                        on: context.listeners,
+                    }),
+                    createElement(DropdownButton, {
+                        props: context.props,
+                    }),
+                ],
+        )
+        },
+    }
+</script>
+
+<style scoped>
+
+</style>
+

--- a/src/components/shared/buttons/SaveButtonWithDropdown.vue
+++ b/src/components/shared/buttons/SaveButtonWithDropdown.vue
@@ -36,8 +36,3 @@
         },
     }
 </script>
-
-<style scoped>
-
-</style>
-

--- a/src/components/shared/buttons/croud-dropdown-button.md
+++ b/src/components/shared/buttons/croud-dropdown-button.md
@@ -1,0 +1,9 @@
+### Basic usage
+Use **menu** prop to populate the dropdown options
+
+    <croud-dropdown-button :menu="[{title: 'Foo', action: () => $toasted.show('Foo')}, {title: 'Bar', action: () => $toasted.show('Bar')}]"/>
+
+### Loading
+Use **loading** prop to set loading state, when loading the dropdown is disabled
+
+    <croud-dropdown-button :loading="true"/>

--- a/src/components/shared/buttons/croud-dropdown-button.md
+++ b/src/components/shared/buttons/croud-dropdown-button.md
@@ -7,3 +7,9 @@ Use **menu** prop to populate the dropdown options
 Use **loading** prop to set loading state, when loading the dropdown is disabled
 
     <croud-dropdown-button :loading="true"/>
+
+
+### Disabled
+Use **disabled** prop to disable dropdown
+
+    <croud-dropdown-button :disabled="true"/>

--- a/src/components/shared/buttons/croud-save-button-with-dropdown.md
+++ b/src/components/shared/buttons/croud-save-button-with-dropdown.md
@@ -7,3 +7,8 @@ Use **menu** prop to populate the dropdown options
 Use **loading** prop to set loading state, when loading the save button and the dropdown atoms are disabled
 
     <croud-save-button-with-dropdown :loading="true" :menu="[{title: 'Foo', action: () => $toasted.show('Foo')}, {title: 'Bar', action: () => $toasted.show('Bar')}]" @click="$toasted.success('saved')"/>
+
+### Disabled
+Use **disabled** prop to set disabled state
+
+    <croud-save-button-with-dropdown :disabled="true" :menu="[{title: 'Foo', action: () => $toasted.show('Foo')}, {title: 'Bar', action: () => $toasted.show('Bar')}]" @click="$toasted.success('saved')"/>

--- a/src/components/shared/buttons/croud-save-button-with-dropdown.md
+++ b/src/components/shared/buttons/croud-save-button-with-dropdown.md
@@ -1,0 +1,9 @@
+### Basic usage
+Use **menu** prop to populate the dropdown options
+
+    <croud-save-button-with-dropdown :menu="[{title: 'Foo', action: () => $toasted.show('Foo')}, {title: 'Bar', action: () => $toasted.show('Bar')}]" @click="$toasted.success('saved')"/>
+
+### Loading
+Use **loading** prop to set loading state, when loading the save button and the dropdown atoms are disabled
+
+    <croud-save-button-with-dropdown :loading="true" :menu="[{title: 'Foo', action: () => $toasted.show('Foo')}, {title: 'Bar', action: () => $toasted.show('Bar')}]" @click="$toasted.success('saved')"/>

--- a/src/components/shared/buttons/croud-save-button.md
+++ b/src/components/shared/buttons/croud-save-button.md
@@ -1,0 +1,11 @@
+### Basic usage
+
+    <croud-save-button @click="$toasted.success('saved')"/>
+
+### Loading State
+Use the loading prop to pass through the components loading state.
+
+When this component is in a loading state, it is disabled and so the click listener will not fire
+
+    <croud-save-button :loading="true" @click="$toasted.success('saved')"/>
+

--- a/src/components/shared/buttons/croud-save-button.md
+++ b/src/components/shared/buttons/croud-save-button.md
@@ -9,3 +9,7 @@ When this component is in a loading state, it is disabled and so the click liste
 
     <croud-save-button :loading="true" @click="$toasted.success('saved')"/>
 
+### Disabled state
+You can also use the disabled prop to disable the button
+
+    <croud-save-button :disabled="true" @click="$toasted.success('saved')"/>

--- a/test/unit/buttons/DropdownButton.spec.js
+++ b/test/unit/buttons/DropdownButton.spec.js
@@ -1,0 +1,31 @@
+
+import Vue from 'vue'
+import DropdownButton from '../../../src/components/shared/buttons/DropdownButton'
+import '../../../semantic/dist/semantic'
+
+
+const Constructor = Vue.extend(DropdownButton)
+
+const vm = new Constructor({
+    propsData: {
+        menu: [
+            { title: 'foo', action: () => console.log('foo') },
+            { title: 'bar', action: () => console.log('bar') },
+        ],
+        loading: false,
+    },
+}).$mount()
+
+describe('DropdownButton', () => {
+    it('should match the snapshot', () => {
+        expect(vm.$el).toMatchSnapshot()
+    })
+
+    it('should disable the dropdown if loading', (done) => {
+        vm.loading = true
+        vm.$nextTick(() => {
+            expect(vm.$el).toMatchSnapshot()
+            done()
+        })
+    })
+})

--- a/test/unit/buttons/SaveButton.spec.js
+++ b/test/unit/buttons/SaveButton.spec.js
@@ -1,0 +1,38 @@
+
+import Vue from 'vue'
+import SaveButton from '../../../src/components/shared/buttons/SaveButton'
+
+const Constructor = Vue.extend({
+    props: {
+        loading: {},
+    },
+    render(h) {
+        return h(SaveButton, {
+            props: {
+                loading: this.loading,
+            },
+        })
+    },
+})
+
+const vm = new Constructor({
+    propsData: {
+        loading: false,
+    },
+}).$mount()
+
+describe('SaveButton', () => {
+    it('should match the snapshot', () => {
+        expect(vm.$el).toMatchSnapshot()
+        expect(vm.$el.disabled).toBe(false)
+    })
+
+    it('should handle a loading state', (done) => {
+        vm.loading = true
+        vm.$nextTick(() => {
+            expect(vm.$el.classList).toContain('loading')
+            expect(vm.$el.disabled).toBe(true)
+            done()
+        })
+    })
+})

--- a/test/unit/buttons/SaveButtonWithDropdown.spec.js
+++ b/test/unit/buttons/SaveButtonWithDropdown.spec.js
@@ -1,0 +1,48 @@
+
+import Vue from 'vue'
+import SaveButtonWithDropdown from '../../../src/components/shared/buttons/SaveButtonWithDropdown'
+import '../../../semantic/dist/semantic'
+
+const Constructor = Vue.extend({
+    props: {
+        loading: {},
+    },
+    render(h) {
+        return h(SaveButtonWithDropdown, {
+            props: {
+                loading: this.loading,
+                menu: [
+                    { title: 'foo', action: () => console.log('foo') },
+                    { title: 'bar', action: () => console.log('bar') },
+                ],
+            },
+        })
+    },
+})
+
+const vm = new Constructor({
+    propsData: {
+        loading: false,
+    },
+}).$mount()
+
+describe('SaveButtonWithDropdown', () => {
+    describe('should build component', () => {
+        it('should match the snapshot', () => {
+            expect(vm.$el).toMatchSnapshot()
+        })
+    })
+
+    it('should handle a loading state', (done) => {
+        vm.loading = true
+        vm.$nextTick(() => {
+            const saveNode = vm.$el.querySelector('.blue.button')
+            const dropdownNode = vm.$el.querySelector('.dropdown.button')
+
+            expect(saveNode.classList).toContain('loading')
+            expect(dropdownNode.classList).toContain('disabled')
+            expect(saveNode.disabled).toBe(true)
+            done()
+        })
+    })
+})

--- a/test/unit/buttons/__snapshots__/DropdownButton.spec.js.snap
+++ b/test/unit/buttons/__snapshots__/DropdownButton.spec.js.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DropdownButton should disable the dropdown if loading 1`] = `
+<div
+  class="ui floating dropdown icon button disabled"
+  tabindex="0"
+>
+  <i
+    class="dropdown icon"
+  />
+  <div
+    class="menu"
+    tabindex="-1"
+  >
+    <div
+      class="item"
+    >
+      foo
+    </div>
+    <div
+      class="item"
+    >
+      bar
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DropdownButton should match the snapshot 1`] = `
+<div
+  class="ui floating dropdown icon button"
+  tabindex="0"
+>
+  <i
+    class="dropdown icon"
+  />
+  <div
+    class="menu"
+    tabindex="-1"
+  >
+    <div
+      class="item"
+    >
+      foo
+    </div>
+    <div
+      class="item"
+    >
+      bar
+    </div>
+  </div>
+</div>
+`;

--- a/test/unit/buttons/__snapshots__/SaveButton.spec.js.snap
+++ b/test/unit/buttons/__snapshots__/SaveButton.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SaveButton should match the snapshot 1`] = `
+<button
+  class="ui blue button"
+>
+  Save
+</button>
+`;

--- a/test/unit/buttons/__snapshots__/SaveButtonWithDropdown.spec.js.snap
+++ b/test/unit/buttons/__snapshots__/SaveButtonWithDropdown.spec.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SaveButtonWithDropdown should build component should match the snapshot 1`] = `
+<div
+  class="ui blue buttons"
+>
+  <button
+    class="ui blue button"
+  >
+    Save
+  </button>
+  <div
+    class="ui floating dropdown icon button"
+    tabindex="0"
+  >
+    <i
+      class="dropdown icon"
+    />
+    <div
+      class="menu"
+      tabindex="-1"
+    >
+      <div
+        class="item"
+      >
+        foo
+      </div>
+      <div
+        class="item"
+      >
+        bar
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Depends on #71 and #70 

This is the component that Product have requested for the WWE changes. It combines the new Save button and Dropdown button atoms into a molecule that provides us with a Save button with additional options. As can be seen in this [sandbox](https://codesandbox.io/s/7mo27n3r66)

This component is another functional component as it is just a wrapper for the two atoms so no state is needed.

Complete with tests, which maybe overkill, but these are more integration tests as opposed to the unit tests in the atom's themselves.

All feedback welcome