### PR TITLE
Add functional component generator templates

### DIFF
--- a/_templates/vue/functionalComponent/component.ejs.t
+++ b/_templates/vue/functionalComponent/component.ejs.t
@@ -1,0 +1,30 @@
+---
+to: src/components/shared/<%= dir %>/<%= name %>.vue
+---
+<%
+ componentName = `croud-${h.inflection.transform(name, ['underscore', 'dasherize']).toLowerCase()}`
+%>
+<script>
+    /**
+    * <%= description %>
+    *
+    * *This is a functional component which has no state so does not need to define any props*
+    * @see https://vuejs.org/v2/guide/render-function.html#Functional-Components
+    *
+    * @example ./<%= componentName %>.md
+    */
+    export default {
+        functional: true,
+
+        name: '<%= componentName %>',
+
+        render(h) {
+            return h('div', "<%= name %>")
+        }
+    }
+</script>
+
+<style scoped>
+
+</style>
+

--- a/_templates/vue/functionalComponent/docs.ejs.t
+++ b/_templates/vue/functionalComponent/docs.ejs.t
@@ -1,0 +1,7 @@
+---
+to: src/components/shared/<%= dir %>/croud-<%= h.inflection.transform(name, ['underscore', 'dasherize']).toLowerCase() %>.md
+---
+### Basic usage
+
+    <croud-<%= h.inflection.transform(name, ['underscore', 'dasherize']).toLowerCase() %> />
+

--- a/_templates/vue/functionalComponent/prompt.js
+++ b/_templates/vue/functionalComponent/prompt.js
@@ -1,0 +1,34 @@
+
+// see types of prompts:
+// https://github.com/SBoudrias/Inquirer.js#prompt-types
+//
+// and for examples for prompts:
+// https://github.com/SBoudrias/Inquirer.js/tree/master/examples
+module.exports = [
+    {
+        type: 'input',
+        name: 'name',
+        message: 'What is the name of your vue component?',
+    },
+    {
+        type: 'list',
+        name: 'dir',
+        message: 'Which dir should your new component be in?',
+        choices: [
+            'buttons',
+            'forms',
+            'hoc',
+            'layout',
+            'menus',
+            'misc',
+            'scheduler',
+            'semantic',
+        ],
+    },
+    {
+        type: 'input',
+        name: 'description',
+        message: 'Give your component a quick description?',
+    },
+
+]

--- a/_templates/vue/functionalComponent/test.ejs.t
+++ b/_templates/vue/functionalComponent/test.ejs.t
@@ -1,0 +1,22 @@
+---
+to: test/unit/<%= dir %>/<%= name %>.spec.js
+---
+
+import Vue from 'vue'
+import <%= name %> from '../../../src/components/shared/<%= dir %>/<%= name %>'
+
+const Constructor = Vue.extend({
+    render(h) {
+        return h(<%= name %>, {
+            props: {},
+        })
+    },
+})
+
+const vm = new Constructor().$mount()
+
+describe('<%= name %>', () => {
+    it('should match the snapshot', () => {
+        expect(vm.$el).toMatchSnapshot()
+    })
+})


### PR DESCRIPTION
As an addition to #69, this adds templates tailored towards [functional components](https://vuejs.org/v2/guide/render-function.html#Functional-Components). Changes to the templates include:

- Removal of template tag in [SFC](https://vuejs.org/v2/guide/single-file-components.html) in favour of a render function, which is backward compatible with functional components.

- Functional option set to true in the component

- Test `Constructor` wraps the functional component in a traditional, stateful component for snapshot testing and reactive props.

**Proposed usage**
Use the following command and answer the same prompts as with the traditional component generator.

```shell
hygen vue functionalComponent
```