### PR TITLE
only call refresh if datagrid still present

### DIFF
--- a/src/components/shared/Datatable.vue
+++ b/src/components/shared/Datatable.vue
@@ -177,7 +177,7 @@
             vuetableConfig: {
                 deep: true,
                 handler: debounce(function () {
-                    this.$refs.vuetable.refresh()
+                    if (this.$refs.vuetable && this.$refs.vuetable.$el) this.$refs.vuetable.refresh()
                 }, 500),
             },
         },


### PR DESCRIPTION
Fix for #74 

This checks for `this.$refs.vuetable && this.$refs.vuetable.$el` as this error can still occur if `this.$refs.vuetable` exists still but $el does not.