### PR TITLE
Feature/cc 1270 class merging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "croud-style-guide",
-  "version": "1.8.4",
+  "version": "1.8.5-0",
   "description": "A Vue.js project",
   "author": "antony.king@croud.co.uk",
   "private": false,

--- a/src/components/shared/buttons/SaveButton.vue
+++ b/src/components/shared/buttons/SaveButton.vue
@@ -17,6 +17,7 @@
                     blue: true,
                     button: true,
                     loading: context.props.loading,
+                    ...context.data.class || {},
                 },
                 attrs: {
                     disabled: context.props.loading || context.props.disabled,

--- a/src/components/shared/buttons/SaveButtonWithDropdown.vue
+++ b/src/components/shared/buttons/SaveButtonWithDropdown.vue
@@ -21,7 +21,12 @@
         render(createElement, context) {
             return createElement('div',
                 {
-                    class: 'ui blue buttons',
+                    class: {
+                        ui: true,
+                        blue: true,
+                        buttons: true,
+                        ...context.data.class || {},
+                    },
                 },
                 [
                     createElement(Save, {
@@ -32,7 +37,7 @@
                         props: context.props,
                     }),
                 ],
-        )
+            )
         },
     }
 </script>


### PR DESCRIPTION
Handle class merging for the functional save components
Prepatch version v.1.8.5-0 publushed for testing

**Usage:**

Class must be passed in as an object from the parent component
```html
<croud-dropdown-save-button :class="{mini: true}" @click="saveEvent" :menu="saveDropdownOptions"/>
```
_Tested locally on feature/CC-1207 branch on monorepo_