### PR TITLE
Feature/summarised dropdown fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "croud-style-guide",
-  "version": "1.8.8",
+  "version": "1.8.9-0",
   "description": "A Vue.js project",
   "author": "antony.king@croud.co.uk",
   "private": false,

--- a/src/components/shared/misc/SummarisedMultiSelector.vue
+++ b/src/components/shared/misc/SummarisedMultiSelector.vue
@@ -155,7 +155,7 @@
         computed: {
             model: {
                 get() {
-                    return this.value
+                    return this.value.length && this.value[0] ? this.value : ''
                 },
 
                 set(val) {

--- a/src/components/shared/misc/SummarisedMultiSelector.vue
+++ b/src/components/shared/misc/SummarisedMultiSelector.vue
@@ -155,11 +155,11 @@
         computed: {
             model: {
                 get() {
-                    return this.value.length && this.value[0] ? this.value : ''
+                    return this.value
                 },
 
                 set(val) {
-                    this.$emit('input', val)
+                    this.getArray(val)
                 },
             },
 
@@ -223,6 +223,11 @@
                     $(this.$refs.summarisedSelector.$el).dropdown('refresh')
                     this.$nextTick(this.$forceUpdate())
                 })
+            },
+
+            getArray(val) {
+                if (val === '') return []
+                return val.split(',')
             },
         },
 

--- a/src/components/shared/misc/SummarisedMultiSelector.vue
+++ b/src/components/shared/misc/SummarisedMultiSelector.vue
@@ -208,8 +208,8 @@
         },
 
         methods: {
-            dropdownSelected(value) {
-                this.$emit('dropdown-selected', value)
+            dropdownSelected(val) {
+                this.$emit('dropdown-selected', this.getArray(val))
             },
 
             setLabel() {

--- a/src/components/shared/misc/SummarisedMultiSelector.vue
+++ b/src/components/shared/misc/SummarisedMultiSelector.vue
@@ -159,7 +159,7 @@
                 },
 
                 set(val) {
-                    this.getArray(val)
+                    this.$emit('input', this.getArray(val))
                 },
             },
 

--- a/src/components/shared/misc/SummarisedMultiSelector.vue
+++ b/src/components/shared/misc/SummarisedMultiSelector.vue
@@ -242,17 +242,30 @@
 <style scoped lang="scss">
     @import '../../../resources/sass/variables/_all.scss';
 
-    .dropdown-wrapper /deep/ .ui.dropdown.search.fluid.multiple.inline {
-        padding: 0;
+    .dropdown-wrapper {
+        width: 100%;
 
-        .menu {
-            overflow-x: visible;
-            overflow-y: visible;
-            max-height: initial;
-        }
+        /deep/ .ui.dropdown {
 
-        span.sizer {
-            display: none;
+            .menu {
+                overflow-x: visible;
+                overflow-y: visible;
+                max-height: initial;
+            }
+
+            .text {
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+            }
+
+            span.sizer {
+                display: none;
+            }
+
+            &.inline {
+                padding: 0;
+            }
         }
     }
 


### PR DESCRIPTION
Filters out an array with a empty value so the placeholder / placeholder summary display when an item is added and then removed

Allows the dropdown to resize to its parent container correctly, also uses an ellipsis if the parent goes to small for the content to prevent text overflow

Related Jiras: https://croudcontrol.atlassian.net/browse/CC-1376, https://croudcontrol.atlassian.net/browse/CC-1374