### PR TITLE
add fluid prop, remove min chars setting (causes bug)

### DIFF
--- a/src/components/shared/forms/SearchDropdown.vue
+++ b/src/components/shared/forms/SearchDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-    <semantic-form-dropdown value="" :options="[]" :settings="computedSettings" :placeholder="placeholder" search/>
+    <semantic-form-dropdown value="" :options="[]" :settings="computedSettings" :placeholder="placeholder" search :fluid="fluid"/>
 </template>
 
 <script>
@@ -35,7 +35,7 @@
             */
             value: {
                 required: false,
-                type: String,
+                type: [String, Number],
             },
 
            /**
@@ -56,6 +56,14 @@
                 default() {
                     return {}
                 },
+            },
+
+            /**
+            * Allow the dropdown to take up available space
+            */
+            fluid: {
+                type: Boolean,
+                default: false,
             },
         },
 
@@ -94,7 +102,6 @@
                         title: 'name',
                         value: 'id',
                     },
-                    minCharacters: 3,
                     selectOnKeydown: false,
                     searchDelay: 200,
                     onChange: (...args) => {


### PR DESCRIPTION
These are a couple of tweaks to be used in https://croudcontrol.atlassian.net/browse/CC-1459

- Adds a fluid prop
- Allows number on value prop
- Removes minCharacter setting, this causes the dropdown to not open/expand when you click the dropdown (very annoying - only clicking the arrow directly opens the dropdown when this is set)

I will look at raising the above issue to semantic